### PR TITLE
[Feat] #11 - AppleLogin 화면 및 기능 구현

### DIFF
--- a/PickPack.xcodeproj/project.pbxproj
+++ b/PickPack.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		33388CD42C6760AF00DECDC3 /* AppleLoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33388CD32C6760AF00DECDC3 /* AppleLoginView.swift */; };
+		33388CD82C67662600DECDC3 /* KeychainHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33388CD72C67662600DECDC3 /* KeychainHelper.swift */; };
+		33388CDA2C67747700DECDC3 /* AppleAuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33388CD92C67747700DECDC3 /* AppleAuthManager.swift */; };
 		FB16D3E32C4D269400FD2F7E /* CarouselView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB16D3E22C4D269400FD2F7E /* CarouselView.swift */; };
 		FB16D4672C52AC7D00FD2F7E /* TicketView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB16D4662C52AC7D00FD2F7E /* TicketView.swift */; };
 		FB16D4692C52ADB800FD2F7E /* EmptyTicketView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB16D4682C52ADB800FD2F7E /* EmptyTicketView.swift */; };
@@ -29,6 +32,10 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		33388CD32C6760AF00DECDC3 /* AppleLoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleLoginView.swift; sourceTree = "<group>"; };
+		33388CD52C6760DB00DECDC3 /* PickPack.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = PickPack.entitlements; sourceTree = "<group>"; };
+		33388CD72C67662600DECDC3 /* KeychainHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainHelper.swift; sourceTree = "<group>"; };
+		33388CD92C67747700DECDC3 /* AppleAuthManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleAuthManager.swift; sourceTree = "<group>"; };
 		FB16D3E22C4D269400FD2F7E /* CarouselView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarouselView.swift; sourceTree = "<group>"; };
 		FB16D4662C52AC7D00FD2F7E /* TicketView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketView.swift; sourceTree = "<group>"; };
 		FB16D4682C52ADB800FD2F7E /* EmptyTicketView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyTicketView.swift; sourceTree = "<group>"; };
@@ -62,6 +69,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		33388CD62C67661600DECDC3 /* Helper */ = {
+			isa = PBXGroup;
+			children = (
+				33388CD72C67662600DECDC3 /* KeychainHelper.swift */,
+			);
+			path = Helper;
+			sourceTree = "<group>";
+		};
 		FBBA97232C3821E500473B51 = {
 			isa = PBXGroup;
 			children = (
@@ -81,9 +96,11 @@
 		FBBA972E2C3821E500473B51 /* PickPack */ = {
 			isa = PBXGroup;
 			children = (
+				33388CD52C6760DB00DECDC3 /* PickPack.entitlements */,
 				FBBA97512C43B88300473B51 /* View */,
 				FBBA974E2C3C20B700473B51 /* Manager */,
 				FBBA972F2C3821E500473B51 /* PickPackApp.swift */,
+				33388CD62C67661600DECDC3 /* Helper */,
 				FBBA97332C3821E700473B51 /* Assets.xcassets */,
 				FBBA973D2C3825C100473B51 /* GoogleService-Info.plist */,
 				FBBA97352C3821E700473B51 /* Preview Content */,
@@ -103,6 +120,7 @@
 			isa = PBXGroup;
 			children = (
 				FBBA974F2C3C20E200473B51 /* AuthManager.swift */,
+				33388CD92C67747700DECDC3 /* AppleAuthManager.swift */,
 			);
 			path = Manager;
 			sourceTree = "<group>";
@@ -117,6 +135,7 @@
 				FB16D3E22C4D269400FD2F7E /* CarouselView.swift */,
 				FB16D4662C52AC7D00FD2F7E /* TicketView.swift */,
 				FB16D4682C52ADB800FD2F7E /* EmptyTicketView.swift */,
+				33388CD32C6760AF00DECDC3 /* AppleLoginView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -204,10 +223,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				33388CDA2C67747700DECDC3 /* AppleAuthManager.swift in Sources */,
 				FBBA97572C43C18100473B51 /* SignInView.swift in Sources */,
+				33388CD42C6760AF00DECDC3 /* AppleLoginView.swift in Sources */,
 				FBBA97532C43B89000473B51 /* SignUpView.swift in Sources */,
 				FB16D4672C52AC7D00FD2F7E /* TicketView.swift in Sources */,
 				FBBA97322C3821E500473B51 /* ContentView.swift in Sources */,
+				33388CD82C67662600DECDC3 /* KeychainHelper.swift in Sources */,
 				FBBA97502C3C20E200473B51 /* AuthManager.swift in Sources */,
 				FB16D3E32C4D269400FD2F7E /* CarouselView.swift in Sources */,
 				FB16D4692C52ADB800FD2F7E /* EmptyTicketView.swift in Sources */,
@@ -343,10 +365,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = PickPack/PickPack.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"PickPack/Preview Content\"";
-				DEVELOPMENT_TEAM = 2UWGKS2UN5;
+				DEVELOPMENT_TEAM = 6FFZZTFJHB;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -354,6 +377,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.2;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -372,10 +396,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = PickPack/PickPack.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"PickPack/Preview Content\"";
-				DEVELOPMENT_TEAM = 2UWGKS2UN5;
+				DEVELOPMENT_TEAM = 6FFZZTFJHB;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -383,6 +408,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.2;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/PickPack/Helper/KeychainHelper.swift
+++ b/PickPack/Helper/KeychainHelper.swift
@@ -1,0 +1,68 @@
+//
+//  KeychainHelper.swift
+//  PickPack
+//
+//  Created by LDW on 8/10/24.
+//
+import Foundation
+
+// MARK: - UserIdentifier를 Keychain으로 관리
+class KeychainHelper {
+    static let shared = KeychainHelper()
+
+    // Keychain에 UserIdentifier 저장
+    func saveUserIdentifier(_ userIdentifier: String) {
+        let data = Data(userIdentifier.utf8)
+        let query = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrAccount: "userIdentifier",
+            kSecValueData: data
+        ] as CFDictionary
+
+        SecItemDelete(query)
+        let status = SecItemAdd(query, nil)
+        
+        if status == errSecSuccess {
+            print("UserIdentifier saved successfully.")
+        } else {
+            print("Failed to save UserIdentifier.")
+        }
+    }
+    
+    // Keychain에서 UserIdentifier 읽기
+    func readUserIdentifier() -> String? {
+        let query = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrAccount: "userIdentifier",
+            kSecReturnData: true,
+            kSecMatchLimit: kSecMatchLimitOne
+        ] as CFDictionary
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query, &result)
+
+        if status == errSecSuccess {
+            if let data = result as? Data {
+                return String(data: data, encoding: .utf8)
+            }
+        }
+        
+        return nil
+    }
+    
+    // Keychain에서 UserIdentifier 삭제
+    func deleteUserIdentifier() {
+          let query = [
+              kSecClass: kSecClassGenericPassword,
+              kSecAttrAccount: "userIdentifier"
+          ] as CFDictionary
+
+          let status = SecItemDelete(query)
+          
+          if status == errSecSuccess {
+              print("UserIdentifier deleted successfully.")
+          } else {
+              print("Failed to delete UserIdentifier.")
+          }
+      }
+}

--- a/PickPack/Manager/AppleAuthManager.swift
+++ b/PickPack/Manager/AppleAuthManager.swift
@@ -1,0 +1,55 @@
+//
+//  AppleAuthManager.swift
+//  PickPack
+//
+//  Created by LDW on 8/10/24.
+//
+
+import Foundation
+import AuthenticationServices
+
+// MARK: - AppleLogin 관련 속성 및 메서드 관리
+final class AppleAuthManager: ObservableObject {
+    @Published var authState = AuthState.signedOut
+    
+    // 현재 기기에 저장된 유저가 있는지 useridentifier를 이용해서 검사  후 로그인 상태를 반영
+    func checkForExistingUser() {
+        if let userIdentifier = KeychainHelper.shared.readUserIdentifier() {
+            print("User already signed in with userIdentifier: \(userIdentifier)")
+            authState = .signedIn
+        } else {
+            print("No stored userIdentifier, user needs to sign in.")
+        }
+    }
+
+    // SignInWithAppleButton의 request에 대해 success 응답이 왔을 때 실행
+    func handleSuccessfulLogin(with authorization: ASAuthorization) {
+        if let userCredential = authorization.credential as? ASAuthorizationAppleIDCredential {
+            let userIdentifier = userCredential.user // 아래 예시 중 userIdentifier 사용
+            KeychainHelper.shared.saveUserIdentifier(userIdentifier) // 저장
+            print(userCredential.user)
+            
+//            응답으로 받은 계정 정보 종류
+//            let UserIdentifier = userCredential.user
+//            let fullName = userCredential.fullName
+//            let name =  (fullName?.familyName ?? "") + (fullName?.givenName ?? "")
+//            let email = userCredential.email
+//            let IdentityToken = String(data: userCredential.identityToken!, encoding: .utf8)
+//            let AuthorizationCode = String(data: userCredential.authorizationCode!, encoding: .utf8)
+            
+            // 정보 출력
+            if userCredential.authorizedScopes.contains(.fullName) {
+                print(userCredential.fullName?.givenName ?? "No given name")
+            }
+            
+            if userCredential.authorizedScopes.contains(.email) {
+                print(userCredential.email ?? "No email")
+            }
+        }
+    }
+    
+    // SignInWithAppleButton의 request에 대해 fail 응답이 왔을 때 실행
+    func handleLoginError(with error: Error) {
+        print("Could not authenticate: \\(error.localizedDescription)")
+    }
+}

--- a/PickPack/PickPack.entitlements
+++ b/PickPack/PickPack.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
+</plist>

--- a/PickPack/PickPackApp.swift
+++ b/PickPack/PickPackApp.swift
@@ -21,7 +21,7 @@ struct PickPackApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) var delegate
     
     // 사용자 Auth 관리
-    @StateObject var authManager: AuthManager = AuthManager()
+    @StateObject var authManager: AppleAuthManager = AppleAuthManager()
     
     var body: some Scene {
         WindowGroup {

--- a/PickPack/View/AppleLoginView.swift
+++ b/PickPack/View/AppleLoginView.swift
@@ -1,0 +1,47 @@
+//
+//  AppleLoginView.swift
+//  PickPack
+//
+//  Created by LDW on 8/10/24.
+//
+import SwiftUI
+import AuthenticationServices
+
+struct AppleLoginView: View {
+    var body: some View {
+        VStack{
+            AppleSigninButton()
+        }
+        .frame(height:UIScreen.main.bounds.height)
+        .background(Color.white)
+    }
+    
+    private struct AppleSigninButton: View {
+        @EnvironmentObject var authManager: AppleAuthManager
+        
+        var body: some View{
+            SignInWithAppleButton(
+                // 이름과 이메일로 인증 요청
+                onRequest: { request in
+                    request.requestedScopes = [.fullName, .email]
+                },
+                onCompletion: { result in
+                    // 요청 결과 처리
+                    switch result {
+                    case .success(let authResults):
+                        print("Apple Login Successful")
+                        authManager.handleSuccessfulLogin(with: authResults)
+                        authManager.authState = .signedIn
+                    case .failure(let error):
+                        authManager.handleLoginError(with: error)
+                        print(error.localizedDescription)
+                        print("error")
+                    }
+                }
+            )
+            .frame(width : UIScreen.main.bounds.width * 0.9, height:50)
+            .cornerRadius(5)
+        }
+    }
+}
+

--- a/PickPack/View/ContentView.swift
+++ b/PickPack/View/ContentView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 import FirebaseAuth
 
 struct ContentView: View {
-    @EnvironmentObject var authManager: AuthManager
+    @EnvironmentObject var authManager: AppleAuthManager
     
     var body: some View {
         NavigationStack {
@@ -18,13 +18,11 @@ struct ContentView: View {
                 if authManager.authState == .signedIn {
                     MainView()
                 } else {
-                    SignInView()
+                    AppleLoginView()
                 }
             }
             .onAppear {
-                if Auth.auth().currentUser != nil {
-                    authManager.authState = .signedIn
-                }
+                authManager.checkForExistingUser()
             }
         }
         

--- a/PickPack/View/MainView.swift
+++ b/PickPack/View/MainView.swift
@@ -8,8 +8,7 @@
 import SwiftUI
 
 struct MainView: View {
-    @EnvironmentObject var authManager: AuthManager
-    
+    @EnvironmentObject var authManager: AppleAuthManager
     @State private var currentIndex = 0
     
     var body: some View {
@@ -28,14 +27,16 @@ struct MainView: View {
             Spacer()
             
             Button {
-                Task {
-                       do {
-                           try await authManager.authSignOut()
-                       }
-                       catch {
-                           print("Error: \(error)")
-                       }
-                   }
+                KeychainHelper.shared.deleteUserIdentifier()
+                authManager.authState = .signedOut
+//                Task {
+//                       do {
+//                           try await authManager.authSignOut()
+//                       }
+//                       catch {
+//                           print("Error: \(error)")
+//                       }
+//                   }
             } label: {
                 Text("로그아웃")
             }
@@ -62,10 +63,10 @@ extension MainView {
                     Circle()
                 )
             
-            Text("\(authManager.user?.displayName)")
-                .font(.headline)
-                .fontWeight(.medium)
-                .foregroundColor(.black)
+//            Text(authManager.user?.displayName ?? "no user")
+//                .font(.headline)
+//                .fontWeight(.medium)
+//                .foregroundColor(.black)
             
             Spacer()
             


### PR DESCRIPTION
<!-- 
Title: [prefix] #이슈번호 - 이슈 내용

Ex) 
// 1번 이슈에서 새로운 기능(Feat)을 구현한 경우
[Feat] #1 - 기능 구현
// 1번 이슈에서 레이아웃(Design)을 구현한 경우
[Design] #1 - 레이아웃 구현

Prefix

[Design]: 뷰 짜기
[Feat]: 새로운 기능 구현
[Fix]: 버그, 오류 해결, 코드 수정
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Docs]: README나 WIKI 등의 문서 개정
[Setting]: 세팅
[Merge]: 머지

-->

## ⭐️Issue
<!-- 현재 PR이 완료되면 함께 닫을 Issue번호 입력 -->
close #10 
<br/>

## 🌟Key Changes
<!-- 이번 PR에서 작업한 핵심적인 변화 -->
- AppleLogin 화면 구현
- SignInWithAppleButton을 이용한 UserInfo 요청 및 결과 분기 처리
- 로그인 시 Keychain에 userIdentifier 저장
- 앱 실행 시 userIdentifier 저장 여부 확인 후 화면 분기
- MainView '로그아웃' 버튼 클릭 시 Keychain의 userIdentifier 삭제
- 기존 화면과 통합
- 개인 계정을 이용했으므로, 출시할 팀 혹은 개인 계정의 AppleDeveloper 설정이 필요할 것으로 예상
- CloudKit 연동하며 수정해야될 것으로 예상
<br/>

https://github.com/user-attachments/assets/82694224-c3ef-403c-a940-eab211663d58

